### PR TITLE
remove session on logout

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -153,8 +153,10 @@ export class Manager extends EventEmitter {
     this.emit('login', this.whatsapp!.info.wid._serialized)
   }
 
-  private onLogout (reason: string = '退出登录') {
+  private async onLogout (reason: string = '退出登录') {
     logger.info(`onLogout(${reason})`)
+    await this.options.memory?.delete(MEMORY_SLOT)
+    await this.options.memory?.save()
     this.emit('logout', this.whatsapp!.info.wid._serialized, reason as string)
   }
 


### PR DESCRIPTION
when session invalid( eg. user logout from phone) it will reload page multiple times, then go `onAuthFailure`  then remove session, so we remove session when logout **immediately** to avoid this.