### PR TITLE
fix message types

### DIFF
--- a/src/pure-function-helpers/message-raw-payload-parser.spec.ts
+++ b/src/pure-function-helpers/message-raw-payload-parser.spec.ts
@@ -1,9 +1,7 @@
 /* eslint-disable sort-keys */
 import { test } from 'tstest'
 import { parserMessageRawPayload } from './message-raw-payload-parser.js'
-import type {
-  WhatsAppMessagePayload,
-} from '../schema/whatsapp-type.js'
+import { MessageTypes } from '../schema/whatsapp-interface.js'
 
 test('message parser for room message which send from bot by web ', async t => {
   const roomMessageFromBotByWeb = {
@@ -16,7 +14,7 @@ test('message parser for room message which send from bot by web ', async t => {
     ack: 0,
     hasMedia: false,
     body: 'ding',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644563786,
     from: '8613126768525@c.us',
     to: '120363039010379837@g.us',
@@ -25,6 +23,7 @@ test('message parser for room message which send from bot by web ', async t => {
     forwardingScore: 0,
     isStatus: false,
     isStarred: false,
+    broadcast: false,
     fromMe: true,
     hasQuotedMsg: false,
     vCards: [],
@@ -32,7 +31,7 @@ test('message parser for room message which send from bot by web ', async t => {
     isGif: false,
     isEphemeral: false,
     links: [],
-  } as WhatsAppMessagePayload
+  }
   const messagePayload = parserMessageRawPayload(roomMessageFromBotByWeb)
   t.ok(
     messagePayload.toId === undefined
@@ -57,12 +56,14 @@ test('message parser for room message which send from bot by api ', async t => {
     ack: 0,
     hasMedia: false,
     body: 'dong',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644563785,
     from: '8613126768525@c.us',
     to: '120363039010379837@g.us',
     deviceType: 'android',
     isForwarded: false,
+    isStatus: false,
+    broadcast: false,
     forwardingScore: 0,
     isStarred: false,
     fromMe: true,
@@ -70,7 +71,9 @@ test('message parser for room message which send from bot by api ', async t => {
     vCards: [],
     mentionedIds: [],
     isGif: false,
-  } as any
+    isEphemeral: false,
+    links: [],
+  }
   const messagePayload = parserMessageRawPayload(roomMessageFromBotByApi)
   t.ok(
     messagePayload.toId === undefined
@@ -92,7 +95,7 @@ test('message parser for room message which send from other contact ', async t =
     ack: 0,
     hasMedia: false,
     body: 'hello',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644565075,
     from: '120363039010379837@g.us',
     to: '8613126768525@c.us',
@@ -110,7 +113,7 @@ test('message parser for room message which send from other contact ', async t =
     isGif: false,
     isEphemeral: false,
     links: [],
-  } as WhatsAppMessagePayload
+  }
   const messagePayload = parserMessageRawPayload(roomMessageFromOtherContact)
   t.ok(
     messagePayload.toId === undefined
@@ -131,7 +134,7 @@ test('message parser for contact message which send from bot by web ', async t =
     ack: 0,
     hasMedia: false,
     body: 'ding',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644564200,
     from: '8613126768525@c.us',
     to: '8618710175700@c.us',
@@ -140,6 +143,7 @@ test('message parser for contact message which send from bot by web ', async t =
     forwardingScore: 0,
     isStatus: false,
     isStarred: false,
+    broadcast: false,
     fromMe: true,
     hasQuotedMsg: false,
     vCards: [],
@@ -147,7 +151,7 @@ test('message parser for contact message which send from bot by web ', async t =
     isGif: false,
     isEphemeral: false,
     links: [],
-  } as WhatsAppMessagePayload
+  }
   const messagePayload = parserMessageRawPayload(contactMessageFromBotByWeb)
   t.ok(
     messagePayload.toId === '8618710175700@c.us'
@@ -168,7 +172,7 @@ test('message parser for contact message which send from bot by api ', async t =
     ack: 0,
     hasMedia: false,
     body: 'dong',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644570007,
     from: '8613126768525@c.us',
     to: '8613811286503@c.us',
@@ -177,6 +181,7 @@ test('message parser for contact message which send from bot by api ', async t =
     forwardingScore: 0,
     isStatus: false,
     isStarred: false,
+    broadcast: false,
     fromMe: true,
     hasQuotedMsg: false,
     vCards: [],
@@ -184,7 +189,7 @@ test('message parser for contact message which send from bot by api ', async t =
     isGif: false,
     isEphemeral: false,
     links: [],
-  } as WhatsAppMessagePayload
+  }
   const messagePayload = parserMessageRawPayload(contactMessageFromBotByApi)
   t.ok(
     messagePayload.toId === '8613811286503@c.us'
@@ -205,7 +210,7 @@ test('message parser for contact message which send from other contact', async t
     ack: 0,
     hasMedia: false,
     body: 'hola',
-    type: 'chat',
+    type: MessageTypes.TEXT,
     timestamp: 1644565052,
     from: '8618500946096@c.us',
     to: '8613126768525@c.us',
@@ -222,7 +227,7 @@ test('message parser for contact message which send from other contact', async t
     isGif: false,
     isEphemeral: false,
     links: [],
-  } as WhatsAppMessagePayload
+  }
   const messagePayload = parserMessageRawPayload(contactMessageFromOtherContact)
   t.ok(
     messagePayload.toId === '8613126768525@c.us'

--- a/src/pure-function-helpers/message-raw-payload-parser.ts
+++ b/src/pure-function-helpers/message-raw-payload-parser.ts
@@ -11,14 +11,15 @@ import type {
   WhatsAppMessagePayload,
 } from '../schema/whatsapp-type.js'
 
-export function parserMessageRawPayload (messagePayload: WhatsAppMessagePayload) {
+export function parserMessageRawPayload (messagePayload: WhatsAppMessagePayload): PUPPET.MessagePayload {
   const fromId = messagePayload.author || messagePayload.from
   let toId: string | undefined
   let roomId: string | undefined
 
   if (typeof messagePayload.id.remote === 'object') {
-    roomId = isRoomId((messagePayload.id.remote as any)._serialized) ? (messagePayload.id.remote as any)._serialized : undefined
-    toId = isRoomId((messagePayload.id.remote as any)._serialized) ? undefined : messagePayload.to
+    const { _serialized } = messagePayload.id.remote
+    roomId = isRoomId(_serialized) ? _serialized : undefined
+    toId = isRoomId(_serialized) ? undefined : messagePayload.to
   } else {
     roomId = isRoomId(messagePayload.id.remote) ? messagePayload.id.remote : undefined
     toId = isRoomId(messagePayload.id.remote) ? undefined : messagePayload.to

--- a/src/schema/whatsapp-type.ts
+++ b/src/schema/whatsapp-type.ts
@@ -1,3 +1,4 @@
+import type { Location } from '@juzi.bot/whatsapp-web.js'
 import type WhatsApp from '@juzi.bot/whatsapp-web.js'
 import type { SetOptional } from 'type-fest'
 
@@ -18,7 +19,7 @@ export type {
   MessageInfo,
   InviteV4Data,
   Message as WhatsAppMessage,
-  MessageId,
+  // MessageId,
   Location,
   Label,
   MessageSendOptions,
@@ -47,9 +48,20 @@ export type {
   List,
 } from '@juzi.bot/whatsapp-web.js'
 
+export interface MessageId {
+  fromMe: boolean,
+  remote: string | {
+    server: string
+    user: string
+    _serialized: string,
+  },
+  id: string,
+  _serialized: string,
+}
+
 export type WhatsAppContactPayload = {
   avatar: string
 } & Omit<WhatsApp.Contact, 'getProfilePicUrl' | 'getChat' | 'getCountryCode' | 'getFormattedNumber' | 'block' | 'unblock' | 'getAbout'>
-export type WhatsAppMessagePayload = Omit<WhatsApp.Message, 'acceptGroupV4Invite' | 'delete' | 'downloadMedia' | 'getChat' | 'getContact' | 'getMentions' | 'getQuotedMessage' | 'reply' | 'forward' | 'star' | 'unstar' | 'getInfo' | 'getOrder' | 'getPayment' | 'broadcast' | 'location' | 'orderId'>
+export type WhatsAppMessagePayload = {mentionedIds: string[], location?:Location, orderId?: string, id: MessageId} & Omit<WhatsApp.Message, 'id' | 'orderId' | 'location' | 'mentionedIds' | 'acceptGroupV4Invite' | 'delete' | 'downloadMedia' | 'getChat' | 'getContact' | 'getMentions' | 'getQuotedMessage' | 'reply' | 'forward' | 'star' | 'unstar' | 'getInfo' | 'getOrder' | 'getPayment'>
 
 export type GroupChat = SetOptional<WhatsApp.GroupChat, 'owner'>


### PR DESCRIPTION
align to official implementation and real practice.
refer: https://github.com/pedroslopez/whatsapp-web.js/blob/11955e9f03986f0c2583b133690a7c2622b7a5d9/src/structures/Message.js

`        this.location = data.type === MessageTypes.LOCATION ? new Location(data.lat, data.lng, data.loc) : undefined;`

```
        /**
         * Indicates the mentions in the message body.
         * @type {Array<string>}
         */
        this.mentionedIds = [];
```

related issue: https://github.com/wechaty/puppet-whatsapp/issues/175