### PR TITLE
regression convert functions

### DIFF
--- a/src/data-manager/cache-manager.ts
+++ b/src/data-manager/cache-manager.ts
@@ -103,7 +103,7 @@ export class CacheManager {
     const cache = this.getContactOrRoomCache()
     // @ts-ignore client is in implementation but not in interface
     const { client, ...rest } = payload
-    await cache.set(id, payload)
+    await cache.set(id, rest)
   }
 
   public deleteContactOrRoom (id: string) {

--- a/src/data-manager/cache-manager.ts
+++ b/src/data-manager/cache-manager.ts
@@ -72,7 +72,9 @@ export class CacheManager {
 
   public async setMessageRawPayload (id: string, payload: WhatsAppMessage): Promise<void> {
     const cache = this.getMessageCache()
-    await cache.set(id, payload)
+    // @ts-ignore client is in implementation but not in interface
+    const { client, ...rest } = payload
+    await cache.set(id, rest)
   }
 
   public deleteMessage (id: string) {
@@ -99,6 +101,8 @@ export class CacheManager {
 
   public async setContactOrRoomRawPayload (id: string, payload: WhatsAppContactPayload): Promise<void> {
     const cache = this.getContactOrRoomCache()
+    // @ts-ignore client is in implementation but not in interface
+    const { client, ...rest } = payload
     await cache.set(id, payload)
   }
 

--- a/src/puppet-mixins/message.ts
+++ b/src/puppet-mixins/message.ts
@@ -121,7 +121,6 @@ export async function messageFile (this: PuppetWhatsApp, messageId: string): Pro
 
 async function downloadMedia (this: PuppetWhatsApp, msg: WhatsAppMessagePayload) {
   const msgObj = convertMessagePayloadToClass(this.manager.getWhatsApp(), msg)
-  msgObj.hasMedia = true // FIXME: workaround for make media could be downloaded. see: https://github.com/wechaty/puppet-whatsapp/issues/165
   const media = await msgObj.downloadMedia()
   const filenameExtension = mime.getExtension(media.mimetype)
   const fileBox = FileBox.fromBase64(media.data, media.filename ?? `unknown_name.${filenameExtension}`)

--- a/src/pure-function-helpers/convert-function.ts
+++ b/src/pure-function-helpers/convert-function.ts
@@ -12,9 +12,13 @@ import type {
 } from '../schema/whatsapp-type.js'
 
 export function convertContactPayloadToClass (client: WhatsAppClientType, payload: WhatsAppContactPayload): WhatsAppContact {
-  return new ContactClass(client, payload)
+  const contactIns = new ContactClass(client)
+  Object.assign(contactIns, payload)
+  return contactIns
 }
 
 export function convertMessagePayloadToClass (client: WhatsAppClientType, payload: WhatsAppMessagePayload): WhatsAppMessage {
-  return new MessageClass(client, payload)
+  const messageIns = new MessageClass(client)
+  Object.assign(messageIns, payload)
+  return messageIns
 }


### PR DESCRIPTION
stored payload are serialize from contact and message instance , not params pass to their constructor, they have different fields, even some fields have same meaning they are different names. this could lead to potential error in future.
fix https://github.com/wechaty/puppet-whatsapp/issues/165
related pr: https://github.com/wechaty/puppet-whatsapp/pull/74