### PR TITLE
Clear timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-whatsapp",
-  "version": "0.41.198",
+  "version": "0.41.200",
   "description": "Wechaty Puppet for WhatsApp",
   "type": "module",
   "exports": {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -986,7 +986,6 @@ export class Manager extends EventEmitter {
   private clearPendingLogoutEmitTimer () {
     if (this.pendingLogoutEmitTimer) {
       clearTimeout(this.pendingLogoutEmitTimer)
-      this.pendingLogoutEmitTimer = undefined
     }
   }
 


### PR DESCRIPTION
After `clearTimeout`, no need to do this: 

```ts
this.pendingLogoutEmitTimer = undefined
```