### PR TITLE
Upgrade to Puppet API v1.19 with deps upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ typings/
 .DS_Store
 t/
 t.*
+.wwebjs_auth/

--- a/examples/ding-dong-bot.ts
+++ b/examples/ding-dong-bot.ts
@@ -105,7 +105,7 @@ function onError (payload: PUPPET.payloads.EventError) {
 async function onMessage (payload: PUPPET.payloads.EventMessage) {
   const msgPayload = await puppet.messagePayload(payload.messageId)
   if ((/ding/i.test(msgPayload.text || ''))) {
-    await puppet.messageSendText(msgPayload.fromId!, 'dong')
+    await puppet.messageSendText(msgPayload.talkerId!, 'dong')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-whatsapp",
-  "version": "1.16.0",
+  "version": "1.19.0",
   "description": "Wechaty Puppet for WhatsApp",
   "type": "module",
   "exports": {
@@ -52,28 +52,28 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/git-scripts": "^0.6.2",
     "@chatie/semver": "^0.4.7",
-    "@chatie/tsconfig": "^4.6.2",
+    "@chatie/tsconfig": "^4.6.3",
     "@types/cuid": "^2.0.1",
     "@types/fs-extra": "^9.0.13",
     "@types/mime": "^2.0.3",
     "@types/node-schedule": "^1.3.2",
     "@types/qrcode-terminal": "^0.12.0",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "tstest": "^1.2.8"
   },
   "peerDependencies": {
-    "wechaty-puppet": "^1.11.17"
+    "wechaty-puppet": "^1.19.4"
   },
   "dependencies": {
     "@juzi/whatsapp-web.js": "1.16.5",
     "ee-ts": "^1.0.2",
-    "flash-store": "^0.12.7",
-    "fs-extra": "^10.0.0",
+    "flash-store": "^1.0.6",
+    "fs-extra": "^10.0.1",
     "gerror": "^1.0.16",
     "mime": "^3.0.0",
-    "node-schedule": "^1.3.2",
-    "rxjs": "^7.5.1",
-    "tap": "^15.1.6",
-    "type-fest": "^2.10.0"
+    "node-schedule": "^2.1.0",
+    "rxjs": "^7.5.5",
+    "type-fest": "^2.12.2"
   },
   "files": [
     "bin/",

--- a/src/helper/pure-function/message-raw-payload-parser.spec.ts
+++ b/src/helper/pure-function/message-raw-payload-parser.spec.ts
@@ -33,9 +33,9 @@ test('message parser for room message which send from bot by web ', async t => {
     links: [],
   }
   const messagePayload = parserMessageRawPayload(roomMessageFromBotByWeb)
-  t.ok(messagePayload.toId === undefined, 'should get no target id')
+  t.ok(messagePayload.listenerId === undefined, 'should get no target id')
   t.ok(messagePayload.roomId === '120363039010379837@g.us', 'should get correct room id')
-  t.ok(messagePayload.fromId === '8613812345679@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345679@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'ding', 'should get correct message content')
 
   t.pass('message parser for room message which send from bot by web pass')
@@ -76,9 +76,9 @@ test('message parser for room message which send from bot by api ', async t => {
   }
   const messagePayload = parserMessageRawPayload(roomMessageFromBotByApi)
 
-  t.ok(messagePayload.toId === undefined, 'should get no target id')
+  t.ok(messagePayload.listenerId === undefined, 'should get no target id')
   t.ok(messagePayload.roomId === '120363039010379837@g.us', 'should get correct room id')
-  t.ok(messagePayload.fromId === '8613812345679@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345679@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'dong', 'should get correct message content')
 
   t.pass('message parser for room message which send from bot by api pass')
@@ -117,9 +117,9 @@ test('message parser for room message which send from other contact ', async t =
   }
   const messagePayload = parserMessageRawPayload(roomMessageFromOtherContact)
 
-  t.ok(messagePayload.toId === undefined, 'should get no target id')
+  t.ok(messagePayload.listenerId === undefined, 'should get no target id')
   t.ok(messagePayload.roomId === '120363039010379837@g.us', 'should get correct room id')
-  t.ok(messagePayload.fromId === '8613812345678@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345678@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'hello', 'should get correct message content')
 
   t.pass('message parser for room message which send from other contact pass')
@@ -156,9 +156,9 @@ test('message parser for contact message which send from bot by web ', async t =
   }
   const messagePayload = parserMessageRawPayload(contactMessageFromBotByWeb)
 
-  t.ok(messagePayload.toId === '8618710175700@c.us', 'should get correct target id')
+  t.ok(messagePayload.listenerId === '8618710175700@c.us', 'should get correct target id')
   t.ok(messagePayload.roomId === undefined, 'should get no room id')
-  t.ok(messagePayload.fromId === '8613812345679@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345679@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'ding', 'should get correct message content')
 
   t.pass('message parser for contact message which send from bot by web pass')
@@ -195,9 +195,9 @@ test('message parser for contact message which send from bot by api ', async t =
   }
   const messagePayload = parserMessageRawPayload(contactMessageFromBotByApi)
 
-  t.ok(messagePayload.toId === '8613811286503@c.us', 'should get correct target id')
+  t.ok(messagePayload.listenerId === '8613811286503@c.us', 'should get correct target id')
   t.ok(messagePayload.roomId === undefined, 'should get no room id')
-  t.ok(messagePayload.fromId === '8613812345679@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345679@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'dong', 'should get correct message content')
 
   t.pass('message parser for contact message which send from bot by api pass')
@@ -234,9 +234,9 @@ test('message parser for contact message which send from other contact', async t
   }
   const messagePayload = parserMessageRawPayload(contactMessageFromOtherContact)
 
-  t.ok(messagePayload.toId === '8613812345679@c.us', 'should get correct target id')
+  t.ok(messagePayload.listenerId === '8613812345679@c.us', 'should get correct target id')
   t.ok(messagePayload.roomId === undefined, 'should get no room id')
-  t.ok(messagePayload.fromId === '8613812345678@c.us', 'shuold get correct sender id')
+  t.ok(messagePayload.talkerId === '8613812345678@c.us', 'shuold get correct sender id')
   t.ok(messagePayload.text === 'hola', 'should get correct message content')
 
   t.pass('message parser for contact message which send from other contact pass')

--- a/src/helper/pure-function/message-raw-payload-parser.ts
+++ b/src/helper/pure-function/message-raw-payload-parser.ts
@@ -12,35 +12,48 @@ import type {
 } from '../../schema/whatsapp-type.js'
 
 export function parserMessageRawPayload (messagePayload: WhatsAppMessagePayload): PUPPET.payloads.Message {
-  const fromId = messagePayload.author || messagePayload.from
-  let toId: string | undefined
+  const talkerId = messagePayload.author || messagePayload.from
+  let listenerId: string | undefined
   let roomId: string | undefined
 
   if (typeof messagePayload.id.remote === 'object') {
     const { _serialized } = messagePayload.id.remote
     roomId = isRoomId(_serialized) ? _serialized : undefined
-    toId = isRoomId(_serialized) ? undefined : messagePayload.to
+    listenerId = isRoomId(_serialized) ? undefined : messagePayload.to
   } else {
     roomId = isRoomId(messagePayload.id.remote) ? messagePayload.id.remote : undefined
-    toId = isRoomId(messagePayload.id.remote) ? undefined : messagePayload.to
+    listenerId = isRoomId(messagePayload.id.remote) ? undefined : messagePayload.to
   }
 
-  if (!fromId) {
-    throw WAError(WA_ERROR_TYPE.ERR_MSG_NOT_FOUND, 'empty fromId!')
+  if (!talkerId) {
+    throw WAError(WA_ERROR_TYPE.ERR_MSG_NOT_FOUND, 'empty talkerIdId!')
   }
 
-  if (!roomId && !toId) {
-    throw WAError(WA_ERROR_TYPE.ERR_MSG_NOT_FOUND, 'empty roomId and empty toId!')
+  if (!roomId && !listenerId) {
+    throw WAError(WA_ERROR_TYPE.ERR_MSG_NOT_FOUND, 'empty roomId and empty listenerId!')
   }
 
   return {
-    fromId,
+    /**
+     * @deprecated `fromId` is deprecated, use `talkerId` instead.
+     *  `fromId` will be removed in v2.0
+     */
+    fromId: talkerId,
+    talkerId,
+    // eslint-disable-next-line sort-keys
     id: messagePayload.id.id,
     mentionIdList: messagePayload.mentionedIds,
     roomId,
     text: messagePayload.body,
     timestamp: messagePayload.timestamp,
-    toId,
+    /**
+     * @deprecated `toId` is deprecated, use `listenerId` instead.
+     *  `toId` will be removed in v2.0
+     */
+    toId: listenerId,
+    // eslint-disable-next-line sort-keys
+    listenerId,
+
     type: getMessageType(messagePayload),
   } as any
 

--- a/src/puppet-mixin/contact-self.ts
+++ b/src/puppet-mixin/contact-self.ts
@@ -1,6 +1,6 @@
 import * as PUPPET from 'wechaty-puppet'
 import { log } from '../config.js'
-import type PuppetWhatsApp from '../puppet-whatsapp'
+import type PuppetWhatsApp from '../puppet-whatsapp.js'
 
 const PRE = 'MIXIN_CONTACT_SELF'
 

--- a/src/puppet-mixin/room.ts
+++ b/src/puppet-mixin/room.ts
@@ -5,7 +5,7 @@ import { WA_ERROR_TYPE } from '../exception/error-type.js'
 import WAError from '../exception/whatsapp-error.js'
 import { contactRawPayload } from './contact.js'
 
-import type PuppetWhatsApp from '../puppet-whatsapp'
+import type PuppetWhatsApp from '../puppet-whatsapp.js'
 import type {
   WhatsAppContactPayload as RoomPayload,
   InviteV4Data,


### PR DESCRIPTION
The most noticeable change is renaming:

1. `fromId` has been deprecated, and will be removed after v2. Use `talkerId` instead.
1. `toId` has been deprecated, and will be removed after v2. Use `listenerId` instead.
